### PR TITLE
Bump `codeclimate-credo` to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV MIX_ENV prod
 RUN mix local.hex --force
 
 RUN git clone https://github.com/michalmuskala/jason
-RUN cd jason && git checkout tags/v1.1.1
+RUN cd jason && git checkout tags/v1.1.2
 RUN cd jason && MIX_ENV=prod mix deps.get --force
 RUN cd jason && MIX_ENV=prod mix archive.build --force
 RUN cd jason && MIX_ENV=prod mix archive.install --force
@@ -29,8 +29,7 @@ RUN cd bunt && MIX_ENV=prod mix deps.get --force
 RUN cd bunt && MIX_ENV=prod mix archive.build --force
 RUN cd bunt && MIX_ENV=prod mix archive.install --force
 
-RUN git clone https://github.com/fazibear/credo
-RUN cd credo && git checkout codeclimate
+RUN git clone https://github.com/codeclimate-community/credo
 RUN cd credo && MIX_ENV=prod mix deps.get --force
 RUN cd credo && MIX_ENV=prod mix archive.build --force
 RUN cd credo && MIX_ENV=prod mix archive.install --force
@@ -40,6 +39,5 @@ RUN cd codeclimate && MIX_ENV=prod mix archive.build --force
 RUN cd codeclimate && MIX_ENV=prod mix archive.install --force
 
 VOLUME /code
-#WORKDIR /code
 
 CMD mix code_climate /code

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-credo 
+
+image:
+	 docker build --rm -t $(IMAGE_NAME) .
+

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CodeClimate.MixProject do
   use Mix.Project
 
-  def version, do: "0.8.10"
+  def version, do: "1.1.0"
 
   def project do
     [


### PR DESCRIPTION
The `codeclimate-credo` plugin is currently using an older version of
`credo` and we'd like to update it to the most recent version.

This change pulls a forked version of `credo`. The current
version of `codeclimate-credo` in production is using a fork of `credo`
from the maintainer with tweaks that enable `credo` to work with Code
Climate's spec. Ideally, we'd like to get those changes merged in
upstream, but just preparing this in case we aren't able to.

This would rely on merging the maintainer's changes into `codeclimate-community/credo`.