### PR TITLE
Refactor to work with `credo` JSON output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM elixir:alpine
 
-MAINTAINER Michał Kalbarczyk "fazibear@gmail.com"
+MAINTAINER Scott Larkin "scott@codeclimate.com"
 
 RUN apk add git bash
 
@@ -18,7 +18,7 @@ ENV MIX_ENV prod
 RUN mix local.hex --force
 
 RUN git clone https://github.com/michalmuskala/jason
-RUN cd jason && git checkout tags/v1.1.1
+RUN cd jason && git checkout tags/v1.1.2
 RUN cd jason && MIX_ENV=prod mix deps.get --force
 RUN cd jason && MIX_ENV=prod mix archive.build --force
 RUN cd jason && MIX_ENV=prod mix archive.install --force
@@ -29,8 +29,7 @@ RUN cd bunt && MIX_ENV=prod mix deps.get --force
 RUN cd bunt && MIX_ENV=prod mix archive.build --force
 RUN cd bunt && MIX_ENV=prod mix archive.install --force
 
-RUN git clone https://github.com/fazibear/credo
-RUN cd credo && git checkout codeclimate
+RUN git clone https://github.com/codeclimate-community/credo
 RUN cd credo && MIX_ENV=prod mix deps.get --force
 RUN cd credo && MIX_ENV=prod mix archive.build --force
 RUN cd credo && MIX_ENV=prod mix archive.install --force
@@ -40,6 +39,5 @@ RUN cd codeclimate && MIX_ENV=prod mix archive.build --force
 RUN cd codeclimate && MIX_ENV=prod mix archive.install --force
 
 VOLUME /code
-#WORKDIR /code
 
 CMD mix code_climate /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM elixir:alpine
 
-MAINTAINER Scott Larkin "scott@codeclimate.com"
+MAINTAINER Michał Kalbarczyk "fazibear@gmail.com"
 
 RUN apk add git bash
 
@@ -29,7 +29,7 @@ RUN cd bunt && MIX_ENV=prod mix deps.get --force
 RUN cd bunt && MIX_ENV=prod mix archive.build --force
 RUN cd bunt && MIX_ENV=prod mix archive.install --force
 
-RUN git clone https://github.com/codeclimate-community/credo
+RUN git clone https://github.com/rrrene/credo
 RUN cd credo && MIX_ENV=prod mix deps.get --force
 RUN cd credo && MIX_ENV=prod mix archive.build --force
 RUN cd credo && MIX_ENV=prod mix archive.install --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cd bunt && MIX_ENV=prod mix deps.get --force
 RUN cd bunt && MIX_ENV=prod mix archive.build --force
 RUN cd bunt && MIX_ENV=prod mix archive.install --force
 
-RUN git clone https://github.com/rrrene/credo
+RUN git clone --depth 1 https://github.com/rrrene/credo
 RUN cd credo && MIX_ENV=prod mix deps.get --force
 RUN cd credo && MIX_ENV=prod mix archive.build --force
 RUN cd credo && MIX_ENV=prod mix archive.install --force

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-credo 
+
+image:
+	 docker build --rm -t $(IMAGE_NAME) .
+

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,3 @@ IMAGE_NAME ?= codeclimate/codeclimate-credo
 
 image:
 	 docker build --rm -t $(IMAGE_NAME) .
-

--- a/lib/code_climate.ex
+++ b/lib/code_climate.ex
@@ -7,21 +7,26 @@ defmodule CodeClimate do
   @cmd "mix"
   @default_opts ~w[credo --format=json]
 
+  @category_duplication "Duplication"
+  @category_clarity "Clarity"
+  @category_complexity "Complexity"
+  @category_bug_risk "Bug Risk"
+
   @issue_category %{
-    "Credo.Check.Design.DuplicatedCode" => ["Duplication"],
-    "Credo.Check.Readability.ModuleDoc" => ["Clarity"],
-    "Credo.Check.Readability.ModuleNames" => ["Clarity"],
-    "Credo.Check.Refactor.ABCSize" => ["Complexity"],
-    "Credo.Check.Refactor.CyclomaticComplexity" => ["Complexity"],
-    "Credo.Check.Warning.NameRedeclarationByFn" => ["Clarity"],
-    "Credo.Check.Warning.OperationOnSameValues" => ["Bug Risk"],
-    "Credo.Check.Warning.BoolOperationOnSameValues" => ["Bug Risk"],
-    "Credo.Check.Warning.UnusedEnumOperation" => ["Bug Risk"],
-    "Credo.Check.Warning.UnusedKeywordOperation" => ["Bug Risk"],
-    "Credo.Check.Warning.UnusedListOperation" => ["Bug Risk"],
-    "Credo.Check.Warning.UnusedStringOperation" => ["Bug Risk"],
-    "Credo.Check.Warning.UnusedTupleOperation" => ["Bug Risk"],
-    "Credo.Check.Warning.OperationWithConstantResult" => ["Bug Risk"]
+    "Credo.Check.Design.DuplicatedCode" => [@category_duplication],
+    "Credo.Check.Readability.ModuleDoc" => [@category_clarity],
+    "Credo.Check.Readability.ModuleNames" => [@category_clarity],
+    "Credo.Check.Refactor.ABCSize" => [@category_complexity],
+    "Credo.Check.Refactor.CyclomaticComplexity" => [@category_complexity],
+    "Credo.Check.Warning.NameRedeclarationByFn" => [@category_clarity],
+    "Credo.Check.Warning.OperationOnSameValues" => [@category_bug_risk],
+    "Credo.Check.Warning.BoolOperationOnSameValues" => [@category_bug_risk],
+    "Credo.Check.Warning.UnusedEnumOperation" => [@category_bug_risk],
+    "Credo.Check.Warning.UnusedKeywordOperation" => [@category_bug_risk],
+    "Credo.Check.Warning.UnusedListOperation" => [@category_bug_risk],
+    "Credo.Check.Warning.UnusedStringOperation" => [@category_bug_risk],
+    "Credo.Check.Warning.UnusedTupleOperation" => [@category_bug_risk],
+    "Credo.Check.Warning.OperationWithConstantResult" => [@category_bug_risk]
   }
 
   def main([path]) do
@@ -46,6 +51,7 @@ defmodule CodeClimate do
       {:ok, res} ->
         %{"issues" => issues} = res
         issues
+
       {:error, err} ->
         raise err
     end
@@ -110,7 +116,6 @@ defmodule CodeClimate do
   defp build_options_from_config(config, path) do
     []
     |> process_include_paths(config, path)
-    |> process_exclude_paths(config, path)
     |> process_strict(config)
     |> process_all(config)
     |> process_only(config)
@@ -125,15 +130,6 @@ defmodule CodeClimate do
   end
 
   defp process_include_paths(opts, _, _), do: opts
-
-  defp process_exclude_paths(opts, %{"exclude_paths" => exclude_paths}, path) do
-    opts ++
-      Enum.map(exclude_paths, fn exlude ->
-        "--files-excluded=#{path}/#{exlude}"
-      end)
-  end
-
-  defp process_exclude_paths(opts, _, _), do: opts
 
   defp process_strict(opts, %{"strict" => true}), do: opts ++ ["--strict"]
   defp process_strict(opts, _), do: opts

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CodeClimate.MixProject do
   use Mix.Project
 
-  def version, do: "0.8.10"
+  def version, do: "1.1.0"
 
   def project do
     [


### PR DESCRIPTION
Borrowing some code from: rrrene/credo#592

The maintainer of `credo` brought up a good point on the PR referenced
above, which is that this plugin can work with the output from credo's
JSON output instead of trying to merge a formatter upstream. This is how
most of our plugins work, actually.

This refactor allows us to pull down the latest version of `credo`
instead of maintaining our own version (the previous version was using a
fork of `credo`).

If this is ok, we should cut over to using this version of `codeclimate-credo` so we can take advantage of the latest `credo` versions.